### PR TITLE
Users can navigate to the explore page by clicking logo

### DIFF
--- a/client/src/components/TopBar.js
+++ b/client/src/components/TopBar.js
@@ -37,7 +37,7 @@ const TopBar = ({ activeUser, searchData, getSearch }) => {
       <>
         <div className="nav-content">
           <div className="logo-container">
-            <Link to={`/profile/${activeUser.id}/${activeUser.username}`}>
+            <Link to={`/explore`}>
               <SampleLogo />
             </Link>
           </div>


### PR DESCRIPTION
# Description

Fixes the DesignHub logo linking to profile instead of explore page.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [x] Click on the logo to be navigated to the explore page

# Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts
